### PR TITLE
feat(certifications): inline PDF modal viewer

### DIFF
--- a/site/src/pages/certifications.astro
+++ b/site/src/pages/certifications.astro
@@ -78,26 +78,39 @@ const ordered = ['kubernetes', 'iac', 'observability', 'devops', 'testing', 'fou
           </div>
           <div class="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             {group.items.map((c) => {
-              const Tag = c.file ? 'a' : 'div';
-              const href = c.file ? `/certificates/${encodeURI(c.file)}` : undefined;
-              const props = c.file ? { href, target: '_blank', rel: 'noopener' } : {};
+              if (c.file) {
+                const href = `/certificates/${encodeURI(c.file)}`;
+                return (
+                  <button
+                    type="button"
+                    data-pdf={href}
+                    data-title={c.title}
+                    class="cert-trigger card p-5 group flex flex-col justify-between text-left transition-colors hover:border-border focus:outline-none focus:border-accent"
+                  >
+                    <div>
+                      <span class="mono-label">{c.issuer}</span>
+                      <h3 class="mt-3 text-card text-text-primary leading-snug">{c.title}</h3>
+                    </div>
+                    <div class="mt-5 flex items-center justify-between">
+                      <span class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary">{c.year}</span>
+                      <span class="inline-flex items-center gap-1.5 font-mono text-mono-meta uppercase tracking-wide text-text-tertiary group-hover:text-accent transition-colors">
+                        view pdf <span aria-hidden="true">↗</span>
+                      </span>
+                    </div>
+                  </button>
+                );
+              }
               return (
-                <Tag {...props} class="card p-5 group flex flex-col justify-between transition-colors hover:border-border">
+                <div class="card p-5 flex flex-col justify-between">
                   <div>
                     <span class="mono-label">{c.issuer}</span>
                     <h3 class="mt-3 text-card text-text-primary leading-snug">{c.title}</h3>
                   </div>
                   <div class="mt-5 flex items-center justify-between">
                     <span class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary">{c.year}</span>
-                    {c.file ? (
-                      <span class="inline-flex items-center gap-1.5 font-mono text-mono-meta uppercase tracking-wide text-text-tertiary group-hover:text-accent transition-colors">
-                        view pdf <span aria-hidden="true">↗</span>
-                      </span>
-                    ) : (
-                      <span class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary">credential on file</span>
-                    )}
+                    <span class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary">credential on file</span>
                   </div>
-                </Tag>
+                </div>
               );
             })}
           </div>
@@ -105,4 +118,88 @@ const ordered = ['kubernetes', 'iac', 'observability', 'devops', 'testing', 'fou
       </section>
     );
   })}
+
+  <!-- PDF viewer modal -->
+  <div
+    id="pdf-modal"
+    class="fixed inset-0 z-50 hidden items-center justify-center p-4 md:p-8 bg-black/80 backdrop-blur-sm"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="pdf-modal-title"
+  >
+    <div class="relative w-full max-w-5xl h-[90vh] bg-bg-card-elevated border border-hairline border-border-subtle rounded-card flex flex-col overflow-hidden">
+      <div class="flex items-center justify-between gap-4 px-5 py-3 border-b border-hairline border-border-subtle">
+        <span id="pdf-modal-title" class="font-mono text-mono-label uppercase tracking-wider text-text-primary truncate"></span>
+        <div class="flex items-center gap-3 shrink-0">
+          <a
+            id="pdf-modal-open"
+            href="#"
+            target="_blank"
+            rel="noopener"
+            class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary hover:text-accent transition-colors inline-flex items-center gap-1.5"
+          >
+            open in tab <span aria-hidden="true">↗</span>
+          </a>
+          <button
+            id="pdf-modal-close"
+            type="button"
+            class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary hover:text-accent transition-colors inline-flex items-center gap-1.5"
+            aria-label="Close PDF viewer"
+          >
+            close <span aria-hidden="true">×</span>
+          </button>
+        </div>
+      </div>
+      <iframe
+        id="pdf-frame"
+        title="Certificate PDF"
+        class="flex-1 w-full bg-bg-primary"
+        loading="lazy"
+      ></iframe>
+    </div>
+  </div>
+
+  <script>
+    const modal = document.getElementById('pdf-modal');
+    const frame = document.getElementById('pdf-frame') as HTMLIFrameElement;
+    const closeBtn = document.getElementById('pdf-modal-close');
+    const titleEl = document.getElementById('pdf-modal-title');
+    const openLink = document.getElementById('pdf-modal-open') as HTMLAnchorElement;
+
+    function openModal(url: string, title: string) {
+      if (!modal || !frame || !titleEl || !openLink) return;
+      frame.src = url;
+      openLink.href = url;
+      titleEl.textContent = title;
+      modal.classList.remove('hidden');
+      modal.classList.add('flex');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeModal() {
+      if (!modal || !frame) return;
+      modal.classList.add('hidden');
+      modal.classList.remove('flex');
+      frame.src = 'about:blank';
+      document.body.style.overflow = '';
+    }
+
+    document.querySelectorAll<HTMLButtonElement>('.cert-trigger').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const url = btn.dataset.pdf;
+        const title = btn.dataset.title ?? 'Certificate';
+        if (url) openModal(url, title);
+      });
+    });
+
+    closeBtn?.addEventListener('click', closeModal);
+    modal?.addEventListener('click', (e) => {
+      if (e.target === modal) closeModal();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && modal && !modal.classList.contains('hidden')) {
+        closeModal();
+      }
+    });
+  </script>
 </Base>


### PR DESCRIPTION
## Summary
Cert cards now open PDFs in a modal overlay on the same page instead of taking the user away. Includes an "open in tab" escape hatch and close via X / Escape / click-outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)