### PR TITLE
fix(work): silkspotter / PowerMeter / ShotKit status + live URLs

### DIFF
--- a/site/src/content/work/powermeter.md
+++ b/site/src/content/work/powermeter.md
@@ -1,12 +1,12 @@
 ---
 title: "PowerMeter"
 category: "product"
-status: "Live · iOS"
+status: "Live · web"
 order: 2
 role: "Solo founder, designer, and engineer"
-summary: "An iPhone-first electricity tracker for South African prepaid users - token logs, cost-per-kWh trends, monthly forecasts, and ZAR-with-VAT context the local utility apps don't show."
-stack: ["SwiftUI", "FastAPI", "PostgreSQL", "Cloudflare"]
-liveUrl: null
+summary: "An electricity tracker for South African prepaid users - token logs, cost-per-kWh trends, monthly forecasts, and ZAR-with-VAT context the local utility apps don't show."
+stack: ["FastAPI", "PostgreSQL", "Cloudflare", "Web (responsive)"]
+liveUrl: "https://powermeter.app/login"
 repoUrl: null
 why: "South African prepaid electricity is opaque by default. PowerMeter is the small thing that makes it legible - typical of consumer software where the right design choice is what's missing, not what's added."
 ---
@@ -19,9 +19,9 @@ A small consumer app that tracks prepaid electricity tokens, computes cost per k
 
 ```mermaid
 flowchart LR
-    User["iPhone (SwiftUI)"] --> API["FastAPI"]
+    Browser["Browser (mobile or desktop)"] --> API["FastAPI"]
     API --> DB["PostgreSQL"]
-    User --> Charts["Local charts and forecasts"]
+    Browser --> Charts["Charts and forecasts"]
 ```
 
 ## What I optimised for
@@ -32,4 +32,4 @@ flowchart LR
 
 ## Status
 
-Live on the App Store. iPhone-only by design - the audience uses iOS in the South African prepaid demographic the app targets, and supporting Android wasn't worth the duplication on a personal-tool budget.
+Live on the open web at [powermeter.app](https://powermeter.app/login). Mobile-first responsive design, no app-store install required - which suits the prepaid-electricity audience and keeps the deployment story simple.

--- a/site/src/content/work/shotkit.md
+++ b/site/src/content/work/shotkit.md
@@ -1,28 +1,28 @@
 ---
 title: "ShotKit"
 category: "product"
-status: "Live · iOS, Android"
+status: "Live · web · iOS / Android in testing"
 order: 3
 role: "Solo founder, designer, and engineer"
 summary: "A photo-craft companion app powered by Claude - composition, lighting, and gear hints based on what the camera is actually seeing right now."
-stack: ["React Native", "Claude API", "Cloudflare Workers"]
-liveUrl: null
+stack: ["React Native", "Claude API", "Cloudflare Workers", "Web (responsive)"]
+liveUrl: "https://shotkit.stewartb.workers.dev"
 repoUrl: null
 why: "Most photo-AI apps generate the photo. ShotKit helps the photographer make it. The product distinction is small but the design implications are not - it changes what the model is allowed to do."
 ---
 
 ## What it is
 
-A pocket assistant for amateur photographers. The phone reads the scene, sends the relevant context to Claude, and gets back composition and lighting hints - framed as suggestions, not autopilot.
+A pocket assistant for amateur photographers. The browser or phone reads the scene, sends the relevant context to Claude, and gets back composition and lighting hints - framed as suggestions, not autopilot.
 
 ## How it works
 
 ```mermaid
 flowchart LR
-    Phone["Phone camera"] --> Edge["Cloudflare Worker"]
+    Client["Browser / Phone camera"] --> Edge["Cloudflare Worker"]
     Edge --> Claude["Claude API"]
     Claude --> Edge
-    Edge --> Phone["Composition / lighting hints"]
+    Edge --> Client["Composition / lighting hints"]
 ```
 
 ## What's interesting about it
@@ -33,4 +33,4 @@ flowchart LR
 
 ## Status
 
-Live on iOS and Android.
+Live on the open web at [shotkit.stewartb.workers.dev](https://shotkit.stewartb.workers.dev). iOS and Android builds are in TestFlight / Play Console internal testing - same React Native codebase, same Cloudflare Worker backend, store rollout still in flight.

--- a/site/src/content/work/silkspotter.md
+++ b/site/src/content/work/silkspotter.md
@@ -1,11 +1,11 @@
 ---
 title: "silkspotter"
 category: "product"
-status: "Live · iOS, Android, web"
+status: "Live · web (gated)"
 order: 1
 role: "Solo founder, designer, and engineer"
-summary: "A Claude-Vision-powered identification app for the kind of objects general-purpose vision models are bad at. Edge inference, prompt caching, adversarial protection - the production hardening most AI demos skip."
-stack: ["React Native", "Cloudflare Workers", "Claude Vision", "Vectorize", "Stripe"]
+summary: "A Claude-Vision-powered identification web app for the kind of objects general-purpose vision models are bad at. Edge inference, prompt caching, adversarial protection - the production hardening most AI demos skip."
+stack: ["Cloudflare Workers", "Claude Vision", "Vectorize", "Web (responsive)"]
 liveUrl: "https://silkspotter.net"
 repoUrl: null
 why: "Real-world Claude Vision in production with edge inference, cost control via caching, and adversarial protection - the kind of production hardening most AI demos skip."
@@ -13,27 +13,26 @@ why: "Real-world Claude Vision in production with edge inference, cost control v
 
 ## What it is
 
-A mobile-first identification app. The user takes a photo, the app calls Claude Vision behind a Cloudflare Worker, and the answer comes back in seconds - with provenance, confidence, and a "why I think this" rationale.
+A mobile-first identification web app. The user takes or uploads a photo, the app calls Claude Vision behind a Cloudflare Worker, and the answer comes back in seconds - with provenance, confidence, and a "why I think this" rationale.
 
 ## How it works
 
 ```mermaid
 flowchart LR
-    Phone["Phone (iOS / Android / Web)"] --> Edge["Cloudflare Worker"]
+    Browser["Browser (mobile or desktop)"] --> Edge["Cloudflare Worker"]
     Edge --> Cache["Prompt + Response Cache"]
     Edge --> Claude["Claude Vision"]
     Claude --> Edge
-    Edge --> Phone
-    Edge --> Billing["Stripe Billing"]
+    Edge --> Browser
 ```
 
 ## What's interesting about it
 
-- **Edge-first.** The Worker is the only thing the phone talks to. No origin server, no warm-pool problem, no cold-start tax.
+- **Edge-first.** The Worker is the only thing the browser talks to. No origin server, no warm-pool problem, no cold-start tax.
 - **Prompt caching.** Repeated prompts hit the cache. Cost per identification is a fraction of the naive call pattern.
 - **Adversarial protection.** Cheap heuristics catch the obvious "is this trying to break out of the prompt" attempts before they hit the model.
-- **Solo end-to-end.** Edge architecture, mobile, billing, store deployment - the whole stack is one engineer's work.
+- **Solo end-to-end.** Edge architecture, frontend, deployment - the whole stack is one engineer's work.
 
 ## Status
 
-Live on App Store, Google Play, and the open web. Real users, real Stripe billing, real Cloudflare bill - the AI cost story actually has to work.
+Live on the open web at silkspotter.net, gated behind an invite code. Real users, real Cloudflare bill - the AI cost story actually has to work.

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -26,7 +26,7 @@ import SectionLabel from '../components/SectionLabel.astro';
           The last two years I've put that foundation to work building the AI layer for engineering teams at scale - pull request review automation across hundreds of production repositories, support tooling that lives where engineers already work, and a metrics layer that gives leadership a real picture of adoption and cost. The throughline is taking AI from "interesting demo" to "load-bearing infrastructure" without breaking governance.
         </p>
         <p>
-          Outside the day job I ship consumer AI products solo: silkspotter, PowerMeter, ShotKit. End-to-end ownership - edge architecture, mobile, billing, store deployment. The discipline of running a real Cloudflare bill against real Stripe revenue is a useful counterweight to enterprise work, where the cost feedback loop is much slower.
+          Outside the day job I ship consumer AI products solo: silkspotter, PowerMeter, ShotKit. End-to-end ownership - edge architecture, frontend, mobile, store deployment. Real users and real production constraints - the kind of hardening that takes a demo to a live app.
         </p>
         <p>
           The career arc is the story behind the work: <a href="https://www.linkedin.com/in/stewart-burton/" rel="me noopener">full history on LinkedIn</a>. The QA and DevOps fundamentals are why the AI work runs in production, not just in demos.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -31,7 +31,7 @@ const pillars = [
     n: '04',
     title: 'AI products, shipped solo',
     body:
-      'silkspotter, PowerMeter, ShotKit - Claude-powered consumer apps live on App Store, Google Play, and the open web. End-to-end ownership: edge architecture, mobile, billing, store deployment.',
+      'silkspotter, PowerMeter, ShotKit - AI-powered consumer apps live on the open web (with mobile builds in testing). End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
     href: '/work/silkspotter',
   },
 ];
@@ -60,15 +60,15 @@ const featured = {
   product: {
     title: 'silkspotter',
     body:
-      'Claude Vision in production. Edge inference, prompt caching, adversarial protection - the kind of hardening most AI demos skip. Live on iOS, Android, and the open web.',
+      'Claude Vision in production. Edge inference, prompt caching, adversarial protection - the kind of hardening most AI demos skip. Live on the open web at silkspotter.net (gated).',
     indicator: 'silkspotter.net',
     href: '/work/silkspotter',
   },
 };
 
 const alsoBuilding = [
-  { title: 'PowerMeter', body: 'iPhone-first electricity tracking with monthly forecasts and ZAR/VAT context.', stack: ['SwiftUI', 'FastAPI', 'PostgreSQL'], href: '/work/powermeter' },
-  { title: 'ShotKit', body: 'Photo-craft companion app powered by Claude - composition, lighting, and gear hints.', stack: ['React Native', 'Claude API', 'Workers'], href: '/work/shotkit' },
+  { title: 'PowerMeter', body: 'Web electricity tracker with monthly forecasts and ZAR/VAT context. Live at powermeter.app.', stack: ['FastAPI', 'PostgreSQL', 'Cloudflare'], href: '/work/powermeter' },
+  { title: 'ShotKit', body: 'Photo-craft companion powered by Claude - composition, lighting, and gear hints. Live on the web; iOS / Android in testing.', stack: ['React Native', 'Claude API', 'Workers'], href: '/work/shotkit' },
   { title: 'izwi', body: 'A small, opinionated language tool for South African languages.', stack: ['Astro', 'Claude API', 'Cloudflare'], href: '/work/izwi' },
   { title: 'Frenchie Trivia', body: 'Trivia game built end-to-end. Light project, real production hosting.', stack: ['Vite', 'Cloudflare Pages'], href: '/work/frenchie-trivia' },
   { title: 'Wildlife migrations', body: 'Visualisation of large-scale animal movement data, dark-mode first.', stack: ['D3', 'Astro', 'Cloudflare'], href: '/work/wildlife-migrations' },


### PR DESCRIPTION
## Summary
- silkspotter: web-only, gated. Dropped App Store / Google Play and Stripe references.
- PowerMeter: web at powermeter.app/login (was inaccurately listed as iOS-only).
- ShotKit: web live at shotkit.stewartb.workers.dev; iOS/Android still in testing (was inaccurately listed as fully Live on iOS, Android).
- Home page + About page reframed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)