### PR TITLE
chore(backups): add full site backup zip (2026-06-23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ website-rebuild-handoff.md
 *.sw?
 .playwright-mcp/
 .astro/
+
+# Website backups: track the .zip archives + README, ignore the unzipped working folders
+backups/*/

--- a/backups/README.md
+++ b/backups/README.md
@@ -1,0 +1,21 @@
+# Backups
+
+Point-in-time backups of the live site (https://www.stewart-burton.com), kept here so any
+visual change that breaks the site can be rolled back to a known-good state.
+
+Each backup is a self-contained `.zip` named `stewart-burton.com_backup_<date>.zip` containing:
+
+- `source/` - full Astro source, rebuildable on its own (`npm install && npm run build`)
+- `rendered/` - the built `dist/` (exactly what GitHub Pages serves)
+- `live-served/` - the HTML the live site returned at capture time
+- `MANIFEST.md` - capture details + restore instructions
+
+Each backup is also pinned as a git tag (`backup/live-<date>`) for a clean source-level revert.
+See the `MANIFEST.md` inside each zip for full restore steps.
+
+> The unzipped working folders are git-ignored; only the `.zip` files and this README are tracked.
+> Backups are additive and do not affect the deployed site (the GitHub Actions deploy only builds `site/`).
+
+| Date | Archive | Git tag | Live commit |
+|---|---|---|---|
+| 2026-06-23 | `stewart-burton.com_backup_2026-06-23.zip` | `backup/live-2026-06-23` | `5f11928` |


### PR DESCRIPTION
Adds a point-in-time backup of the live site before upcoming layout edits, so a broken change can be rolled back.

## What's added
- `backups/stewart-burton.com_backup_2026-06-23.zip` (14.5 MB) - self-contained snapshot:
  - `source/` - full Astro source, rebuildable on its own (`npm install && npm run build`)
  - `rendered/` - the built `dist/` GitHub Pages serves (22 pages, byte-for-byte)
  - `live-served/` - HTML the live site returned at capture time (6 routes)
  - `MANIFEST.md` - capture details + restore instructions
- `backups/README.md` - index + restore guide
- `.gitignore` - track the `.zip` + README, ignore the unzipped working folders

Also pinned as git tag `backup/live-2026-06-23` (live commit `5f11928`) for a clean source-level revert.

## Notes
- Purely additive - the deploy workflow only builds `site/`, so this does not change the live site.
- Cloudflare's only role for this site is DNS + proxy/CDN in front of GitHub Pages; there is no Worker/Pages project to back up. DNS records can be exported from the Cloudflare dashboard if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)