### PR TITLE
Add Fettle to the solo AI products list on home and about

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -28,7 +28,7 @@ import speaking from '../data/speaking.json';
           The last two years I've put that foundation to work building the AI layer for engineering teams at scale - pull request review automation across hundreds of production repositories, support tooling that lives where engineers already work, and a metrics layer that gives leadership a real picture of adoption and cost. The throughline is taking AI from "interesting demo" to "load-bearing infrastructure" without breaking governance.
         </p>
         <p>
-          Outside the day job I ship consumer AI products solo: silkspotter, PowerMeter, ShotKit. End-to-end ownership - edge architecture, frontend, mobile, store deployment. Real users and real production constraints - the kind of hardening that takes a demo to a live app.
+          Outside the day job I ship consumer AI products solo: silkspotter, PowerMeter, ShotKit, Fettle. End-to-end ownership - edge architecture, frontend, mobile, store deployment. Real users and real production constraints - the kind of hardening that takes a demo to a live app.
         </p>
         <p>
           The career arc is the story behind the work: <a href="https://www.linkedin.com/in/stewart-burton/" rel="me noopener">full history on LinkedIn</a>. The QA and DevOps fundamentals are why the AI work runs in production, not just in demos.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,7 +37,7 @@ const pillars = [
     n: '04',
     title: 'AI products, shipped solo',
     body:
-      'silkspotter, PowerMeter, ShotKit - AI-powered consumer apps live on the open web (with mobile builds in testing). End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
+      'silkspotter, PowerMeter, ShotKit, Fettle - AI-powered consumer apps live on the open web (with mobile builds in testing). End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
     href: '/work/silkspotter',
   },
 ];


### PR DESCRIPTION
Follow-up to #18. Fettle has its own work-page entry (beta, PWA live, iOS in TestFlight) but was missing from the two places that list the solo-shipped consumer AI products:

- `site/src/pages/about.astro`: bio now reads "silkspotter, PowerMeter, ShotKit, Fettle."
- `site/src/pages/index.astro`: the "AI products, shipped solo" pillar lists the same four.

Build passes (29 pages) and both rendered pages contain the updated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_