### PR TITLE
Link solo AI products to their live sites and add izwi

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -28,7 +28,7 @@ import speaking from '../data/speaking.json';
           The last two years I've put that foundation to work building the AI layer for engineering teams at scale - pull request review automation across hundreds of production repositories, support tooling that lives where engineers already work, and a metrics layer that gives leadership a real picture of adoption and cost. The throughline is taking AI from "interesting demo" to "load-bearing infrastructure" without breaking governance.
         </p>
         <p>
-          Outside the day job I ship consumer AI products solo: silkspotter, PowerMeter, ShotKit, Fettle. End-to-end ownership - edge architecture, frontend, mobile, store deployment. Real users and real production constraints - the kind of hardening that takes a demo to a live app.
+          Outside the day job I ship consumer AI products solo: <a href="https://silkspotter.net" rel="noopener">silkspotter</a>, <a href="https://powermeter.app" rel="noopener">PowerMeter</a>, <a href="https://shotkit.stewartb.workers.dev" rel="noopener">ShotKit</a>, <a href="https://fettle.tools" rel="noopener">Fettle</a>, <a href="https://apps.apple.com/za/app/izwi/id6761016017" rel="noopener">izwi</a>. End-to-end ownership - edge architecture, frontend, mobile, store deployment. Real users and real production constraints - the kind of hardening that takes a demo to a live app.
         </p>
         <p>
           The career arc is the story behind the work: <a href="https://www.linkedin.com/in/stewart-burton/" rel="me noopener">full history on LinkedIn</a>. The QA and DevOps fundamentals are why the AI work runs in production, not just in demos.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,7 +37,7 @@ const pillars = [
     n: '04',
     title: 'AI products, shipped solo',
     body:
-      'silkspotter, PowerMeter, ShotKit, Fettle - AI-powered consumer apps live on the open web (with mobile builds in testing). End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
+      'silkspotter, PowerMeter, ShotKit, Fettle, izwi - AI-powered consumer apps live on the open web and the App Store, with more mobile builds in testing. End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
     href: '/work/silkspotter',
   },
 ];


### PR DESCRIPTION
Follow-up to #19.

- `site/src/pages/about.astro`: the bio's product list now includes izwi and links each name to its live destination, sourced from each case study's `liveUrl` frontmatter: silkspotter.net, powermeter.app, shotkit.stewartb.workers.dev, fettle.tools, and izwi's App Store page. All five URLs verified reachable (HTTP 200).
- `site/src/pages/index.astro`: the "AI products, shipped solo" pillar adds izwi and now reads "live on the open web and the App Store, with more mobile builds in testing" (izwi is released on the App Store). Names stay plain text there because the whole pillar card is already an anchor - nested links are invalid HTML.

Build passes (29 pages); about page screenshot confirms the links render in the site's existing accent link style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_