### PR TITLE
Add agentic workflows and AI coding agent enablement to the role card

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -59,6 +59,8 @@ import speaking from '../data/speaking.json';
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> GitHub and Azure DevOps integration</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Developer productivity tooling</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> CI/CD automation and platform enablement</li>
+          <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Agentic workflow automation - event triggers, scheduled runs and iterative agent loops</li>
+          <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> AI coding agent enablement - authoring Claude skills (SKILL.md), GitHub Copilot instructions (copilot-instructions.md) and Codex agent guidance (AGENTS.md)</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Secure, measurable AI adoption inside engineering teams</li>
         </ul>
       </div>


### PR DESCRIPTION
Follow-up to #20. Adds two focus areas to the current-role card on /about, between "CI/CD automation and platform enablement" and "Secure, measurable AI adoption":

- "Agentic workflow automation - event triggers, scheduled runs and iterative agent loops"
- "AI coding agent enablement - authoring Claude skills (SKILL.md), GitHub Copilot instructions (copilot-instructions.md) and Codex agent guidance (AGENTS.md)"

Build passes (29 pages); screenshot-verified that the card still renders cleanly with seven items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_