### PR TITLE
Describe the Grafana on OpenShift GitOps delivery in the reporting case study

### DIFF
--- a/site/src/content/work/pr-review-management-reporting.md
+++ b/site/src/content/work/pr-review-management-reporting.md
@@ -4,8 +4,8 @@ category: "enterprise"
 status: "Live in production"
 order: 7
 role: "Designer and builder"
-summary: "A reporting layer for AI PR review rollout - central metrics store, organisation inventory scans, adoption status, and leadership-ready summaries - turning per-pipeline-run telemetry into a governance picture leaders can act on."
-stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "Metrics pipelines", "Reporting templates"]
+summary: "A reporting layer for AI PR review rollout - central metrics store, organisation inventory scans, adoption status, and self-service Grafana dashboards on OpenShift - turning per-pipeline-run telemetry into a governance picture leaders can act on."
+stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "Metrics pipelines", "Grafana", "OpenShift", "ArgoCD"]
 liveUrl: null
 repoUrl: null
 why: "Technical proof that AI review works isn't enough. Leaders sign off on adoption, cost, and risk - not on how the model classifies severity. This is the layer that converts engineering telemetry into the evidence model that gets the rollout funded."
@@ -17,7 +17,7 @@ The AI PR review systems generated useful per-run data: token counts, finding di
 
 ## The approach
 
-Build a thin reporting layer on top of the pipelines. Every review run already wrote a metrics artifact; now those artifacts get collected centrally. Add an organisation inventory scanner so the rollout list is always derived from real repository state, not a stale spreadsheet. Generate weekly and on-demand summaries in a format leadership can actually read.
+Build a thin reporting layer on top of the pipelines. Every review run already wrote a metrics artifact; now those artifacts get collected centrally. Add an organisation inventory scanner so the rollout list is always derived from real repository state, not a stale spreadsheet. Generate weekly and on-demand summaries in a format leadership can actually read. The consolidated picture is served through Grafana dashboards on OpenShift, delivered via GitOps so the reporting surface can evolve as quickly as the questions leadership asks.
 
 ## How it works
 
@@ -28,7 +28,10 @@ flowchart LR
     Inventory["Org Inventory Scanner"] --> Collector
     Collector --> Store["Central Metrics Store"]
     Store --> Reports["Summary Reports"]
+    Store --> Grafana["Grafana Dashboards on OpenShift"]
+    Git["Code + Dashboard Definitions (Git)"] --> ArgoCD["ArgoCD (GitOps)"] --> Grafana
     Reports --> Leaders["Management / InfoSec / DevOps Leads"]
+    Grafana --> Leaders
 ```
 
 ## What I built
@@ -38,11 +41,12 @@ flowchart LR
 - **Org inventory scanner.** Scans the source-control estate and tags each repository with its rollout state - onboarded, advisory, enforced, opted-out, archived.
 - **Rollout status exports.** Generated weekly. Adoption count, cost trend, finding distribution, top repositories by review volume.
 - **Leadership summaries.** Pre-formatted briefs and presentation-ready material. Same source data, different audience.
+- **Grafana dashboards on OpenShift, delivered via GitOps.** The metrics store is surfaced through Grafana dashboards running on OpenShift, with ArgoCD watching the repository. Any change to the collector code or dashboard definitions is detected and deployed automatically - when leadership requests a new metric or view, the change ships on commit and appears on the next dashboard refresh, with no manual deployment step.
 
 ## Outcome
 
-The reporting cadence dropped from "manual one-day exercise per cycle" to "scripted in minutes." The conversation in leadership reviews shifted from "is the AI review actually being used?" to "do we want to expand the rollout to the next set of repositories?" - which is the conversation worth having.
+The reporting cadence dropped from "manual one-day exercise per cycle" to "scripted in minutes." The conversation in leadership reviews shifted from "is the AI review actually being used?" to "do we want to expand the rollout to the next set of repositories?" - which is the conversation worth having. Because delivery is GitOps-driven, requested metrics and dashboard changes reach management without deployment ceremony: commit the change, ArgoCD syncs it, and a dashboard refresh shows the new view.
 
 ## What I'd do next
 
-Surface the same data through a small web dashboard so the metrics layer becomes self-service. The data is already there; it just needs a viewing surface. That work converts the reporting layer from a "send me the brief" interaction into a "I'll go look" one - which scales much better as adoption grows.
+Threshold alerting on the same data - cost drift, adoption stalls, unusual finding spikes - so the dashboards flag what needs attention instead of waiting to be checked. The GitOps pipeline makes that an incremental change: define alert rules in the repository and ArgoCD ships them like everything else.


### PR DESCRIPTION
Follow-up to #21. The /work/pr-review-management-reporting case study never mentioned how the reporting layer is actually served: Grafana dashboards on OpenShift, delivered via ArgoCD GitOps.

Changes to `site/src/content/work/pr-review-management-reporting.md`:

- **Summary + stack**: summary now mentions self-service Grafana dashboards on OpenShift; stack adds Grafana, OpenShift, ArgoCD.
- **Approach**: one sentence on the GitOps-delivered Grafana serving layer.
- **Diagram**: adds the serving path (Store to Grafana dashboards to leaders) and the delivery path (Git to ArgoCD to Grafana). Diagram syntax validated with mermaid 11 (parses and renders to SVG).
- **What I built**: new bullet describing the dashboards and the automatic deployment flow - changes to code or dashboard definitions are detected by ArgoCD and deployed with no manual step, so requested metrics appear on the next dashboard refresh.
- **Outcome**: one sentence on GitOps removing deployment ceremony.
- **What I'd do next**: rewritten - it previously described a self-service dashboard as future work, which the Grafana deployment has since delivered. Now proposes threshold alerting on the same data.

Build passes (29 pages); page screenshot-verified; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_