### PR TITLE
Add OpenAI API and GitHub Models API to the reporting case study stack

### DIFF
--- a/site/src/content/work/pr-review-management-reporting.md
+++ b/site/src/content/work/pr-review-management-reporting.md
@@ -5,7 +5,7 @@ status: "Live in production"
 order: 7
 role: "Designer and builder"
 summary: "A reporting layer for AI PR review rollout - central metrics store, organisation inventory scans, adoption status, and self-service Grafana dashboards on OpenShift - turning per-pipeline-run telemetry into a governance picture leaders can act on."
-stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "Metrics pipelines", "Grafana", "OpenShift", "ArgoCD"]
+stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "OpenAI API", "GitHub Models API", "Metrics pipelines", "Grafana", "OpenShift", "ArgoCD"]
 liveUrl: null
 repoUrl: null
 why: "Technical proof that AI review works isn't enough. Leaders sign off on adoption, cost, and risk - not on how the model classifies severity. This is the layer that converts engineering telemetry into the evidence model that gets the rollout funded."


### PR DESCRIPTION
Follow-up to #23. Adds "OpenAI API" and "GitHub Models API" to the `stack` frontmatter of `site/src/content/work/pr-review-management-reporting.md`, after "GitHub APIs".

Note on display: the top meta card shows only the first three stack items by design (`data.stack.slice(0, 3)` in the case-study template), so it keeps reading "Python · Azure DevOps APIs · GitHub APIs" - the new entries appear in the full stack list at the bottom of the page, same as every other case study.

Build passes (29 pages); built page contains both new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_