### PR TITLE
Show up to six stack chips in the case-study meta card

### DIFF
--- a/site/src/content/work/pr-review-management-reporting.md
+++ b/site/src/content/work/pr-review-management-reporting.md
@@ -5,7 +5,7 @@ status: "Live in production"
 order: 7
 role: "Designer and builder"
 summary: "A reporting layer for AI PR review rollout - central metrics store, organisation inventory scans, adoption status, and self-service Grafana dashboards on OpenShift - turning per-pipeline-run telemetry into a governance picture leaders can act on."
-stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "OpenAI API", "GitHub Models API", "Metrics pipelines", "Grafana", "OpenShift", "ArgoCD"]
+stack: ["Python", "Azure DevOps APIs", "GitHub APIs", "OpenAI API", "Grafana", "OpenShift", "GitHub Models API", "Metrics pipelines", "ArgoCD"]
 liveUrl: null
 repoUrl: null
 why: "Technical proof that AI review works isn't enough. Leaders sign off on adoption, cost, and risk - not on how the model classifies severity. This is the layer that converts engineering telemetry into the evidence model that gets the rollout funded."

--- a/site/src/pages/work/[...slug].astro
+++ b/site/src/pages/work/[...slug].astro
@@ -84,7 +84,7 @@ const breadcrumbSection =
         </div>
         <div class="card p-5">
           <dt class="mono-label">stack</dt>
-          <dd class="mt-3"><StackChips items={data.stack.slice(0, 3)} /></dd>
+          <dd class="mt-3"><StackChips items={data.stack.slice(0, 6)} /></dd>
         </div>
       </dl>
     </div>


### PR DESCRIPTION
Follow-up to #24. The top STACK meta card on case-study pages capped at the first three stack items, which hid Grafana and OpenShift on the reporting case study.

- `site/src/pages/work/[...slug].astro`: `data.stack.slice(0, 3)` becomes `slice(0, 6)` - applies to the meta card on all case studies; chips wrap to a second line and the card layout holds.
- `site/src/content/work/pr-review-management-reporting.md`: stack reordered so the card shows Python, Azure DevOps APIs, GitHub APIs, OpenAI API, Grafana, OpenShift (GitHub Models API, Metrics pipelines, ArgoCD remain in the full stack list at the bottom).

Build passes (29 pages); screenshot-verified the six-chip card on the reporting page and on ai-pr-reviews-azure-devops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_