### PR TITLE
Note that cost drift is reported in both USD and ZAR

### DIFF
--- a/site/src/content/work/pr-review-management-reporting.md
+++ b/site/src/content/work/pr-review-management-reporting.md
@@ -42,7 +42,7 @@ flowchart LR
 - **Rollout status exports.** Generated weekly. Adoption count, cost trend, finding distribution, top repositories by review volume.
 - **Leadership summaries.** Pre-formatted briefs and presentation-ready material. Same source data, different audience.
 - **Grafana dashboards on OpenShift, delivered via GitOps.** The metrics store is surfaced through two Grafana dashboards running on OpenShift: one covering AI PR reviews on Azure DevOps (review volume, comments, usage and cost) and one covering AI PR reviews on GitHub (review volume and comments). ArgoCD watches the repository, so any change to the collector code or dashboard definitions is detected and deployed automatically - when leadership requests a new metric or view, the change ships on commit and appears on the next dashboard refresh, with no manual deployment step.
-- **Threshold monitoring on the rollout signals.** The dashboards track cost drift, adoption stalls, and unusual finding spikes, so deviations surface as they happen rather than at the next reporting cycle. Alert rules live in the repository and ship through the same ArgoCD pipeline as everything else.
+- **Threshold monitoring on the rollout signals.** The dashboards track cost drift (reported in both USD and ZAR), adoption stalls, and unusual finding spikes, so deviations surface as they happen rather than at the next reporting cycle. Alert rules live in the repository and ship through the same ArgoCD pipeline as everything else.
 
 ## Outcome
 


### PR DESCRIPTION
Follow-up to #26. One-line update to the threshold-monitoring bullet in `site/src/content/work/pr-review-management-reporting.md`: cost drift is now described as "reported in both USD and ZAR".

Build passes (29 pages); phrase verified in the built page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJKDUKSTjz2AwZnwDV52PG)_