### PR TITLE
Add remote-session MCP tool approvals to local Claude settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,9 @@
       "Read(C:\\Users\\stewa/**)",
       "Read(C:\\Users\\stewa/**)",
       "Bash(npx playwright:*)",
-      "Bash(del screenshot.js)"
+      "Bash(del screenshot.js)",
+      "mcp__bf7c680d-5fdc-5ef4-b4a0-abadb619bf0a__register_repo_root",
+      "mcp__bf7c680d-5fdc-5ef4-b4a0-abadb619bf0a__delete_trigger"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
Adds two remote-session MCP tools (`register_repo_root` and `delete_trigger`) to the tracked `.claude/settings.local.json` permission allowlist, and fixes the missing trailing newline in that file. These entries were recorded when the tools were approved during a Claude Code remote session.

No site content is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzuKZCsBjVM2SZ4MscmvLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzuKZCsBjVM2SZ4MscmvLG)_