### PR TITLE
Describe SKILL.md as a portable agent skill format, not Claude-only

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -74,7 +74,7 @@ const prEndorsement = endorsements['ai-pr-reviews-azure-devops'];
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Developer productivity tooling</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> CI/CD automation and platform enablement</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Agentic workflow automation - event triggers, scheduled runs and iterative agent loops</li>
-          <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> AI coding agent enablement - authoring Claude skills (SKILL.md), GitHub Copilot instructions (copilot-instructions.md) and Codex agent guidance (AGENTS.md)</li>
+          <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> AI coding agent enablement - authoring portable agent skills (SKILL.md) used across OpenAI Codex, Claude and GitHub Copilot, plus repo-level agent guidance (AGENTS.md, copilot-instructions.md)</li>
           <li class="flex gap-3"><span class="text-accent" aria-hidden="true">↳</span> Secure, measurable AI adoption inside engineering teams</li>
         </ul>
       </div>


### PR DESCRIPTION
The about page listed "authoring Claude skills (SKILL.md)". In practice the SKILL.md skills are used mainly by company developers running OpenAI Codex, and also in Claude models and GitHub Copilot, so the Claude-only framing understated the scope.

Bullet now reads:

> AI coding agent enablement - authoring portable agent skills (SKILL.md) used across OpenAI Codex, Claude and GitHub Copilot, plus repo-level agent guidance (AGENTS.md, copilot-instructions.md)

Only occurrence in the site source; the resume and one-pager do not carry this line. Site builds clean (30 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3