### PR TITLE
Split independent products onto /smaller-things and link the lab to business use

### DIFF
--- a/site/src/components/TopNav.astro
+++ b/site/src/components/TopNav.astro
@@ -1,10 +1,11 @@
 ---
 const { current } = Astro.props as {
-  current?: 'home' | 'work' | 'lab' | 'about' | 'services' | 'contact';
+  current?: 'home' | 'work' | 'smaller-things' | 'lab' | 'about' | 'services' | 'contact';
 };
 
 const navItems = [
   { href: '/work', label: 'work', key: 'work' },
+  { href: '/smaller-things', label: 'smaller things', key: 'smaller-things' },
   { href: '/lab', label: 'lab', key: 'lab' },
   { href: '/about', label: 'about', key: 'about' },
   { href: '/services', label: 'services', key: 'services' },
@@ -17,7 +18,7 @@ const navItems = [
     <a href="/" class="font-mono text-card-sm text-text-primary tracking-tight">
       stewart-burton<span class="text-accent">.com</span>
     </a>
-    <ul class="flex items-center gap-6">
+    <ul class="flex flex-wrap items-center gap-x-6 gap-y-2">
       {navItems.map((item) => (
         <li>
           <a

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro';
 interface Props {
   title: string;
   description?: string;
-  current?: 'home' | 'work' | 'lab' | 'about' | 'services' | 'contact';
+  current?: 'home' | 'work' | 'smaller-things' | 'lab' | 'about' | 'services' | 'contact';
 }
 const {
   title,

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from 'astro:content';
 import Base from '../layouts/Base.astro';
 import SectionLabel from '../components/SectionLabel.astro';
 import StackChips from '../components/StackChips.astro';
@@ -8,6 +9,11 @@ import speaking from '../data/speaking.json';
 import endorsements from '../data/endorsements.json';
 
 const prEndorsement = endorsements['ai-pr-reviews-azure-devops'];
+
+const allWork = await getCollection('work');
+const productEntries = allWork.filter((e) => e.data.category === 'product');
+const productCount = productEntries.length;
+const liveCount = productEntries.filter((e) => e.data.status.startsWith('Live')).length;
 
 const pillars = [
   {
@@ -37,8 +43,8 @@ const pillars = [
     n: '04',
     title: 'AI products, shipped solo',
     body:
-      'Hadeda Havoc, Fettle, izwi, PowerMeter, ShotKit - thirteen consumer products built solo: a paid iOS game on the App Store, apps on iOS and Android, and live web apps. End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
-    href: '/work/hadeda-havoc',
+      'Hadeda Havoc, Fettle, izwi, PowerMeter, ShotKit - twelve consumer products built solo: a paid iOS game on the App Store, apps on iOS and Android, and live web apps. End-to-end ownership: edge architecture, frontend, mobile, and the production hardening that takes a demo to a live app.',
+    href: '/smaller-things',
   },
 ];
 
@@ -71,18 +77,6 @@ const featured = {
     href: '/work/silkspotter',
   },
 };
-
-const alsoBuilding = [
-  { title: 'Fettle', body: 'Cross-brand smart catalog for the toolbox - snap a photo, Fettle identifies the tool and matches batteries across brands. iOS app in TestFlight.', stack: ['Cloudflare Workers', 'Claude Vision', 'Expo'], href: '/work/fettle' },
-  { title: 'Hadeda Havoc', body: "One-tap arcade flyer starring South Africa's most beloved noisy bird. Live and paid on the iOS App Store.", stack: ['Expo', 'React Native', 'EAS Build'], href: '/work/hadeda-havoc' },
-  { title: 'Home AI lab', body: 'Local-first AI platform on a single 12 GB GPU - six local models, warm voice pipeline, RAG memory, and a supervised personal agent, in daily use at home.', stack: ['llama.cpp', 'Qwen3', 'Qdrant'], href: '/lab' },
-  { title: 'PowerMeter', body: 'Multi-tenant electricity tracker for SA prepaid users - token logs, monthly forecasts, ZAR-with-VAT context, and an AI meter-reading scan. Live on web + iOS/Android.', stack: ['Cloudflare Workers', 'React Native/Expo', 'Claude Vision'], href: '/work/powermeter' },
-  { title: 'ShotKit', body: 'Natural-language DJI drone mission planner - describe a cinematic shot in plain English, get a flight-ready KMZ with terrain-aware safety checks. Live on web; iPad app.', stack: ['Cloudflare Workers', 'Claude API', 'Expo (iPad)'], href: '/work/shotkit' },
-  { title: 'izwi', body: 'Widget-first South African word discovery - a different word lands on your home screen every morning, across isiZulu, isiXhosa, Afrikaans and more. Live on iOS + Android.', stack: ['Expo/React Native', 'Swift/SwiftUI', 'TypeScript'], href: '/work/izwi' },
-  { title: 'Frenchie Trivia', body: 'French Bulldog trivia app - 1,100 questions across 14 categories, ranked play, leaderboards, and an offline-capable game engine. iOS/Android in development.', stack: ['Expo/React Native', 'Cloudflare Workers', 'Firebase Auth'], href: '/work/frenchie-trivia' },
-  { title: 'Wildlife migrations', body: 'Interactive 3D globe visualising migration routes for 62 species, aggregating real data from Movebank, eBird, and Journey North. Live on the web.', stack: ['React', 'Mapbox GL JS', 'Cloudflare Workers'], href: '/work/wildlife-migrations' },
-  { title: 'Powerball ML', body: 'Statistical intelligence for SA Powerball - 1,740 draws scraped, and a split-aware expected-value engine with a backtested 2.41x payout lift. Not a tip service.', stack: ['Python/FastAPI', 'Next.js', 'Prisma'], href: '/work/powerball' },
-];
 ---
 
 <Base title="Home" current="home">
@@ -281,22 +275,34 @@ const alsoBuilding = [
       <SectionLabel label="also building" />
       <h2 class="mt-4 text-h2 text-text-primary">Smaller things that ship.</h2>
       <p class="mt-3 max-w-prose text-body text-text-secondary">
-        Side projects, experiments, and tools - each one live somewhere. The point is the shipping muscle, not the codebase.
+        Side projects, experiments and tools, built solo and shipped end to end. The point is the shipping muscle, not any one codebase.
       </p>
 
-      <div class="mt-10 grid gap-3 md:grid-cols-3">
-        {alsoBuilding.map((p) => (
-          <a href={p.href} class="card p-5 group">
-            <h3 class="inline-flex items-center gap-2 text-card text-text-primary">
-              {p.title}
-              <span class="text-accent text-mono-meta" aria-hidden="true">↗</span>
-            </h3>
-            <p class="mt-3 text-card-body text-text-secondary">{p.body}</p>
-            <div class="mt-5">
-              <StackChips items={p.stack} />
-            </div>
-          </a>
-        ))}
+      <div class="mt-10 grid gap-3 md:grid-cols-2">
+        <a href="/smaller-things" class="card-elevated p-8 group flex flex-col justify-between">
+          <div>
+            <span class="mono-label">shipped solo</span>
+            <h3 class="mt-3 text-card-lead text-text-primary">{productCount} independent products</h3>
+            <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+              {liveCount} of them live on the App Store, Google Play or the open web. Built end to end: edge architecture, mobile and web clients, billing, store submission, and the tests that hold it together.
+            </p>
+          </div>
+          <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+            see them all <span class="text-accent" aria-hidden="true">→</span>
+          </span>
+        </a>
+        <a href="/lab" class="card-elevated p-8 group flex flex-col justify-between">
+          <div>
+            <span class="mono-label">the platform underneath</span>
+            <h3 class="mt-3 text-card-lead text-text-primary">Home AI lab</h3>
+            <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+              Six local models on one 12 GB GPU, an explicit local-vs-cloud routing policy, retrieval memory with citations, and a supervised agent under least privilege. Run as daily infrastructure.
+            </p>
+          </div>
+          <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+            see the lab <span class="text-accent" aria-hidden="true">→</span>
+          </span>
+        </a>
       </div>
     </div>
   </section>

--- a/site/src/pages/lab.astro
+++ b/site/src/pages/lab.astro
@@ -119,6 +119,29 @@ const built = [
   },
 ];
 
+const business = [
+  {
+    n: '01',
+    h: 'Data that is not allowed to leave',
+    p: 'Regulated, contractual or simply sensitive material can be worked on by a model that never makes an outbound call. The routing policy is the control: local-only is a rule with no escalation path, not a preference someone can override on a deadline.',
+  },
+  {
+    n: '02',
+    h: 'Cost that does not scale with headcount',
+    p: 'Per-seat AI licences grow linearly with the org chart. Owned capacity does not. The sizing work is what makes that trade real rather than theoretical: knowing which jobs a 4B model does perfectly well is worth more than access to a bigger one.',
+  },
+  {
+    n: '03',
+    h: 'Answers that cite the internal source',
+    p: 'Retrieval over your own documents, returning citations into the real document rather than a confident paragraph with no provenance. That is the difference between a tool a compliance team can accept and one it cannot.',
+  },
+  {
+    n: '04',
+    h: 'Agents that can be signed off',
+    p: 'Least privilege, tool allowlists, tiered approvals and an audit trail on every action. The governance questions an enterprise asks before letting software act on its systems are the same ones this lab already answers.',
+  },
+];
+
 const stack = [
   'llama.cpp',
   'llama-swap',
@@ -399,6 +422,42 @@ const stack = [
             </span>
           </a>
         ))}
+      </div>
+    </div>
+  </section>
+
+  <div class="mx-auto max-w-page px-8 section-divider"></div>
+
+  <!-- For a business -->
+  <section>
+    <div class="mx-auto max-w-page px-8 py-section grid md:grid-cols-[200px_1fr] gap-x-10 gap-y-8">
+      <SectionLabel label="for a business" />
+      <div class="min-w-0">
+        <h2 class="text-h2 text-text-primary">The same stack, pointed at a company's problem.</h2>
+        <p class="mt-5 max-w-prose text-body text-text-body">
+          Most organisations that want AI cannot simply post their data to a hosted API, and most
+          that can are paying per seat for capability they could own. This is what the lab is a
+          working answer to, at a scale small enough to prove cheaply.
+        </p>
+
+        <ul class="mt-8 space-y-6">
+          {business.map((b) => (
+            <li class="grid grid-cols-[2rem_1fr] gap-x-4">
+              <span class="font-mono text-mono-label text-accent pt-1">{b.n}</span>
+              <div>
+                <h3 class="text-card text-text-primary">{b.h}</h3>
+                <p class="mt-2 max-w-prose text-body text-text-secondary">{b.p}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <a
+          href="/services"
+          class="inline-flex items-center gap-2 mt-10 font-mono text-mono-label uppercase tracking-wider text-accent hover:underline"
+        >
+          private ai as an engagement <span aria-hidden="true">→</span>
+        </a>
       </div>
     </div>
   </section>

--- a/site/src/pages/services.astro
+++ b/site/src/pages/services.astro
@@ -34,6 +34,15 @@ const services = [
   },
   {
     n: '05',
+    title: 'Private AI on your own infrastructure',
+    body:
+      'For teams whose data cannot go to a hosted API - regulated, contractual, or simply sensitive. Open-weight models served on hardware you control, sized against a real VRAM budget rather than a benchmark headline; a written local-vs-cloud routing policy so nothing sensitive leaks into a vendor by default; retrieval over your own documents that answers with citations; and agents held to least privilege with approvals and an audit trail. It also changes the cost shape: capacity you own instead of a per-seat licence that scales with headcount. I run exactly this stack daily on a single 12 GB GPU - the constraint is the point, because it forces the sizing and scheduling decisions a bigger budget lets you skip.',
+    deliverables: ['Model + hardware sizing', 'Routing policy (local vs cloud)', 'RAG over internal docs', 'Agent guardrails + audit', 'Cost model vs per-seat licences'],
+    href: '/lab',
+    hrefLabel: 'see it running',
+  },
+  {
+    n: '06',
     title: 'AI product engineering',
     body:
       'Solo or with a small team - design, build, and ship an AI-powered product on the right model for the job (Anthropic, OpenAI, Google, ElevenLabs, or open-weights). Edge architecture, prompt caching, billing integration, store deployment, and the test automation that takes a demo to a live app with real users.',
@@ -50,7 +59,7 @@ const services = [
         What I bring to an engineering team. <span class="text-accent">Each capability shipped before, not theorised.</span>
       </h1>
       <p class="mt-6 max-w-prose text-body text-text-secondary">
-        I'm looking for a <span class="text-text-primary">full-time role</span> - permanent, in South Africa, hybrid, or fully remote (UK / Europe timezone-friendly with a British passport). The five areas below are the work I'd be hitting the ground running on. They're capabilities I'd plug into a team, not a contractor menu.
+        I'm looking for a <span class="text-text-primary">full-time role</span> - permanent, in South Africa, hybrid, or fully remote (UK / Europe timezone-friendly with a British passport). The six areas below are the work I'd be hitting the ground running on. They're capabilities I'd plug into a team, not a contractor menu.
       </p>
     </div>
   </section>
@@ -89,6 +98,14 @@ const services = [
                   ))}
                 </ul>
               </div>
+            )}
+            {s.href && (
+              <a
+                href={s.href}
+                class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary hover:text-accent transition-colors"
+              >
+                {s.hrefLabel ?? 'read more'} <span class="text-accent" aria-hidden="true">→</span>
+              </a>
             )}
           </article>
         ))}

--- a/site/src/pages/smaller-things.astro
+++ b/site/src/pages/smaller-things.astro
@@ -1,0 +1,149 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../layouts/Base.astro';
+import SectionLabel from '../components/SectionLabel.astro';
+import WorkCard from '../components/WorkCard.astro';
+
+const all = await getCollection('work');
+const products = all
+  .filter((e) => e.data.category === 'product')
+  .sort((a, b) => a.data.order - b.data.order);
+
+const isLive = (s: string) => s.startsWith('Live');
+const isPersonal = (s: string) => s.startsWith('Personal project');
+
+const live = products.filter((p) => isLive(p.data.status));
+const personal = products.filter((p) => isPersonal(p.data.status));
+const building = products.filter((p) => !isLive(p.data.status) && !isPersonal(p.data.status));
+
+const groups = [
+  {
+    key: 'live',
+    label: 'live',
+    heading: 'Out in the world.',
+    blurb:
+      'On the App Store, on Google Play, or on the open web, with real users and the production hardening that takes a demo to a live app.',
+    items: live,
+  },
+  {
+    key: 'building',
+    label: 'in build',
+    heading: 'Close, not out yet.',
+    blurb: 'In TestFlight, in private pilot, or still being finished. Listed because the work is real, not because it shipped.',
+    items: building,
+  },
+  {
+    key: 'personal',
+    label: 'personal',
+    heading: 'Built for one user.',
+    blurb: 'Made to scratch my own itch. No store listing, no roadmap, and none of the pretence that there is one.',
+    items: personal,
+  },
+];
+
+const description =
+  'Independent products shipped solo - mobile apps, web apps and tools, live on the App Store, Google Play and the open web.';
+---
+
+<Base title="Smaller things" description={description} current="smaller-things">
+  <section>
+    <div class="mx-auto max-w-page px-8 pt-16 pb-section">
+      <SectionLabel label="smaller things" />
+      <h1 class="mt-6 text-page-h1 text-text-primary max-w-prose">
+        Smaller things that ship. <span class="text-accent">{products.length} of them.</span>
+      </h1>
+      <p class="mt-6 max-w-prose text-body-lead text-text-body">
+        Side projects, experiments and tools, built solo and end to end: edge architecture, mobile
+        and web clients, billing, store submissions, and the test automation that turns a demo into
+        something strangers can use. The point is the shipping muscle, not any one codebase.
+      </p>
+      <p class="mt-5 max-w-prose text-body text-text-secondary">
+        Enterprise AI and DevOps work lives on <a href="/work" class="text-accent hover:underline">work</a>.
+        The platform most of this gets built on is the
+        <a href="/lab" class="text-accent hover:underline">home AI lab</a>.
+      </p>
+
+      <dl class="mt-12 grid gap-3 sm:grid-cols-3">
+        <div class="card p-6">
+          <dt class="mono-label">live</dt>
+          <dd class="mt-3 text-card-lead text-text-primary">{live.length}</dd>
+          <dd class="mt-2 text-card-body text-text-secondary">App Store, Google Play, open web</dd>
+        </div>
+        <div class="card p-6">
+          <dt class="mono-label">in build</dt>
+          <dd class="mt-3 text-card-lead text-text-primary">{building.length}</dd>
+          <dd class="mt-2 text-card-body text-text-secondary">TestFlight, private pilot, in progress</dd>
+        </div>
+        <div class="card p-6">
+          <dt class="mono-label">personal</dt>
+          <dd class="mt-3 text-card-lead text-text-primary">{personal.length}</dd>
+          <dd class="mt-2 text-card-body text-text-secondary">Built for one user, me</dd>
+        </div>
+      </dl>
+    </div>
+  </section>
+
+  {groups.map((g) => g.items.length > 0 && (
+    <>
+      <div class="mx-auto max-w-page px-8 section-divider"></div>
+      <section>
+        <div class="mx-auto max-w-page px-8 py-section">
+          <div class="flex items-end justify-between gap-6 flex-wrap">
+            <div>
+              <SectionLabel label={g.label} />
+              <h2 class="mt-4 text-h2 text-text-primary">{g.heading}</h2>
+            </div>
+            <span class="font-mono text-mono-label uppercase tracking-wider text-text-tertiary">
+              {g.items.length.toString().padStart(2, '0')} / {products.length.toString().padStart(2, '0')}
+            </span>
+          </div>
+          <p class="mt-5 max-w-prose text-body text-text-secondary">{g.blurb}</p>
+          <div class="mt-10 grid gap-3 md:grid-cols-3">
+            {g.items.map((p) => (
+              <WorkCard
+                title={p.data.title}
+                summary={p.data.summary}
+                status={p.data.status}
+                stack={p.data.stack}
+                href={`/work/${p.slug}`}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  ))}
+
+  <div class="mx-auto max-w-page px-8 section-divider"></div>
+
+  <section>
+    <div class="mx-auto max-w-page px-8 py-section grid gap-3 md:grid-cols-2">
+      <a href="/lab" class="card-elevated p-8 group flex flex-col justify-between">
+        <div>
+          <span class="mono-label">the workshop behind them</span>
+          <h2 class="mt-3 text-card-lead text-text-primary">Home AI lab</h2>
+          <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+            Local model serving, retrieval memory and coding agents on one 12 GB GPU. Most of these
+            products were built with it.
+          </p>
+        </div>
+        <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+          see the lab <span class="text-accent" aria-hidden="true">→</span>
+        </span>
+      </a>
+      <a href="/work" class="card-elevated p-8 group flex flex-col justify-between">
+        <div>
+          <span class="mono-label">the other body of work</span>
+          <h2 class="mt-3 text-card-lead text-text-primary">Enterprise AI and DevOps</h2>
+          <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+            AI code review across hundreds of production repositories, support tooling, and
+            enterprise-scale migration platforms. Governance, scale and rollout.
+          </p>
+        </div>
+        <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+          see the work <span class="text-accent" aria-hidden="true">→</span>
+        </span>
+      </a>
+    </div>
+  </section>
+</Base>

--- a/site/src/pages/work/[...slug].astro
+++ b/site/src/pages/work/[...slug].astro
@@ -47,16 +47,19 @@ const sectionLabel =
     : data.category === 'open-source'
     ? 'open source'
     : 'independent product';
-const breadcrumbSection =
-  data.category === 'product' ? 'Independent products' : 'Enterprise AI/DevOps';
+const isProduct = data.category === 'product';
+const breadcrumbRoot = isProduct
+  ? { href: '/smaller-things', label: 'smaller things' }
+  : { href: '/work', label: 'work' };
+const breadcrumbSection = isProduct ? 'Shipped solo' : 'Enterprise AI/DevOps';
 ---
 
-<Base title={data.title} description={data.summary} current="work">
+<Base title={data.title} description={data.summary} current={isProduct ? 'smaller-things' : 'work'}>
   <article>
     <!-- Breadcrumb -->
     <div class="mx-auto max-w-page px-8 pt-12">
       <nav class="font-mono text-mono-meta uppercase tracking-wide text-text-tertiary">
-        <a href="/work" class="hover:text-accent transition-colors">work</a>
+        <a href={breadcrumbRoot.href} class="hover:text-accent transition-colors">{breadcrumbRoot.label}</a>
         <span class="mx-2 text-border-strong" aria-hidden="true">/</span>
         <span>{breadcrumbSection}</span>
         <span class="mx-2 text-border-strong" aria-hidden="true">/</span>

--- a/site/src/pages/work/index.astro
+++ b/site/src/pages/work/index.astro
@@ -8,9 +8,7 @@ const all = await getCollection('work');
 const enterprise = all
   .filter((e) => e.data.category === 'enterprise' || e.data.category === 'open-source')
   .sort((a, b) => a.data.order - b.data.order);
-const products = all
-  .filter((e) => e.data.category === 'product')
-  .sort((a, b) => a.data.order - b.data.order);
+const productCount = all.filter((e) => e.data.category === 'product').length;
 ---
 
 <Base title="Work" current="work">
@@ -18,10 +16,16 @@ const products = all
     <div class="mx-auto max-w-page px-8 py-section">
       <SectionLabel label="work" />
       <h1 class="mt-6 text-page-h1 text-text-primary max-w-prose">
-        Two bodies of work. <span class="text-accent">Enterprise AI/DevOps</span>, and AI products shipped solo.
+        <span class="text-accent">Enterprise AI and DevOps</span>, built inside a production estate.
       </h1>
       <p class="mt-6 max-w-prose text-body text-text-secondary">
-        Each column proves something different. Enterprise = governance, scale, rollout. Independent = end-to-end ownership. Same engineer behind both.
+        AI code review across hundreds of repositories, support tooling that lives where engineers
+        already work, and migration platforms built for scale. What this column proves is
+        governance, rollout and the discipline of shipping into someone else's production.
+      </p>
+      <p class="mt-5 max-w-prose text-body text-text-secondary">
+        The other side of the picture, {productCount} products shipped solo, is on
+        <a href="/smaller-things" class="text-accent hover:underline">smaller things</a>.
       </p>
     </div>
   </section>
@@ -36,7 +40,7 @@ const products = all
           <h2 class="mt-4 text-h2 text-text-primary">Built inside the enterprise.</h2>
         </div>
         <span class="font-mono text-mono-label uppercase tracking-wider text-text-tertiary">
-          {enterprise.length.toString().padStart(2, '0')} / {all.length.toString().padStart(2, '0')}
+          {enterprise.length.toString().padStart(2, '0')} case studies
         </span>
       </div>
       {enterprise.length === 0 ? (
@@ -61,43 +65,30 @@ const products = all
   <div class="mx-auto max-w-page px-8 section-divider"></div>
 
   <section>
-    <div class="mx-auto max-w-page px-8 py-section">
-      <div class="flex items-end justify-between gap-6 flex-wrap">
+    <div class="mx-auto max-w-page px-8 py-section grid gap-3 md:grid-cols-2">
+      <a href="/smaller-things" class="card-elevated p-8 group flex flex-col justify-between">
         <div>
-          <SectionLabel label="independent products" />
-          <h2 class="mt-4 text-h2 text-text-primary">Shipped solo, end to end.</h2>
-        </div>
-        <span class="font-mono text-mono-label uppercase tracking-wider text-text-tertiary">
-          {products.length.toString().padStart(2, '0')} / {all.length.toString().padStart(2, '0')}
-        </span>
-      </div>
-      {products.length === 0 ? (
-        <p class="mt-10 text-body text-text-secondary">No product pages published yet.</p>
-      ) : (
-        <div class="mt-10 grid gap-3 md:grid-cols-3">
-          {products.map((p) => (
-            <WorkCard
-              title={p.data.title}
-              summary={p.data.summary}
-              status={p.data.status}
-              stack={p.data.stack}
-              href={`/work/${p.slug}`}
-            />
-          ))}
-        </div>
-      )}
-
-      <a href="/lab" class="mt-3 card-elevated p-8 group flex items-center justify-between gap-6 flex-wrap">
-        <div>
-          <span class="mono-label">the workshop behind them</span>
-          <h3 class="mt-3 text-card-lead text-text-primary">Home AI lab</h3>
-          <p class="mt-3 max-w-prose text-card-body text-text-secondary">
-            A local-first AI platform on one 12 GB GPU: six local models, an explicit local-vs-cloud
-            routing policy, retrieval memory, and a supervised agent under least privilege. Run as
-            daily infrastructure, not a demo.
+          <span class="mono-label">shipped solo</span>
+          <h2 class="mt-3 text-card-lead text-text-primary">Smaller things that ship</h2>
+          <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+            {productCount} independent products - mobile and web apps on the App Store, Google Play
+            and the open web. End-to-end ownership, from edge architecture to store submission.
           </p>
         </div>
-        <span class="inline-flex items-center gap-2 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+        <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
+          see them <span class="text-accent" aria-hidden="true">→</span>
+        </span>
+      </a>
+      <a href="/lab" class="card-elevated p-8 group flex flex-col justify-between">
+        <div>
+          <span class="mono-label">the platform underneath</span>
+          <h2 class="mt-3 text-card-lead text-text-primary">Home AI lab</h2>
+          <p class="mt-3 text-card-body text-text-secondary max-w-prose">
+            A local-first AI platform on one 12 GB GPU: six local models, an explicit local-vs-cloud
+            routing policy, retrieval memory, and a supervised agent under least privilege.
+          </p>
+        </div>
+        <span class="inline-flex items-center gap-2 mt-6 font-mono text-mono-label uppercase tracking-wider text-text-primary group-hover:text-accent transition-colors">
           see the lab <span class="text-accent" aria-hidden="true">→</span>
         </span>
       </a>


### PR DESCRIPTION
## Why

The homepage's nine-card "smaller things that ship" grid was a duplicate of `/work`'s Independent products section. Moving it to its own page without changing anything else would have made a third copy of the same 12 products.

## Structure

Each body of work now owns exactly one page:

| Page | Owns |
|---|---|
| `/work` | Enterprise AI and DevOps, 9 case studies |
| `/smaller-things` | The 12 independent products, grouped live (6) / in build (4) / personal (2) |
| `/lab` | The platform underneath |

Product case studies stay at `/work/<slug>`, so no URLs break. Their breadcrumb root and nav highlight now point at `/smaller-things`.

Counts are derived from the content collection on all three pages plus the homepage, so they can't drift when a product is added.

## Homepage

Keeps the section and its voice, trades the 3x3 grid for two cards through to `/smaller-things` and `/lab`. Page height drops from roughly 5,600px to 4,600px.

## Linking the lab to business use

The lab had no corporate framing at all. Two additions:

- **Services entry 05, "Private AI on your own infrastructure"**: model and hardware sizing, a written local-vs-cloud routing policy, RAG over internal docs with citations, agent guardrails and audit, and the cost model against per-seat licences. Links through to `/lab` as proof it runs.
- **"For a business" section on `/lab`**: four concrete applications (data that cannot leave, cost that does not scale with headcount, answers that cite the internal source, agents that can be signed off), linking back to services.

## Verification

- Build clean, 31 pages
- Internal link check across the whole `dist` tree: no missing targets
- Playwright at 1280 and 390: no horizontal overflow, six-item nav wraps to two lines on mobile rather than overflowing, group counts render 6 / 4 / 2 against 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3