### PR TITLE
Correct the lab's tooling claims and add the security and memory layers

### DIFF
--- a/site/src/pages/lab.astro
+++ b/site/src/pages/lab.astro
@@ -54,23 +54,31 @@ const layers = [
   },
   {
     n: 'Coding agents',
-    d: 'Continue, Cline and Aider wired into VS Code against local coding models, with a frontier cloud model kept for the work that genuinely needs it.',
+    d: 'Claude Code, OpenAI Codex and GitHub Copilot, steered by portable SKILL.md skills and AGENTS.md guidance that work across all three rather than being written per vendor. The local coding model is driven by the lab\'s own agent for sandboxed development work, not through an IDE plugin.',
   },
   {
     n: 'Voice',
     d: 'faster-whisper for speech in, Kokoro for speech out, held resident by a persistent voice service. Keeping both models warm instead of cold-starting them per request took a turn from about 14 seconds to about 1.4.',
   },
   {
-    n: 'Memory',
-    d: 'A plain-Markdown knowledge vault embedded into Qdrant. Answers come back grounded, with citations pointing at real notes rather than at the model.',
+    n: 'Retrieval memory',
+    d: 'An Obsidian vault of plain Markdown, embedded into Qdrant. Answers come back grounded, with citations pointing at the real note rather than at the model. The notes stay ordinary files on disk, so nothing gets trapped inside a database.',
+  },
+  {
+    n: 'Agent memory',
+    d: 'Separate from retrieval, the coding agents carry their own: CLAUDE.md and AGENTS.md instruction files at global and per-project scope, plus memory notes that persist decisions, corrections and constraints between sessions. Retrieval answers what was written down. This is what stops the same correction being needed twice.',
   },
   {
     n: 'Automation',
     d: 'n8n as the automation bus, Home Assistant for the physical layer, and a Stream Deck of one-press launchers for the whole platform.',
   },
   {
+    n: 'Home security',
+    d: 'Cameras ride Home Assistant events instead of streaming: when an armed camera reports a person, the already-captured frame is pulled (no stream, no battery cost), described by the local vision model, and pushed to my phone through a self-hosted ntfy channel. Per-camera cooldowns, empty-frame suppression and quiet hours keep it from becoming noise. No footage leaves the house and there is no cloud vision subscription. The same channel carries the platform\'s own watchdog alerts.',
+  },
+  {
     n: 'Image generation',
-    d: 'ComfyUI running SDXL and Flux.1 schnell, scheduled around the language model by the bus. The lab generates its own launcher icons.',
+    d: 'ComfyUI running SDXL and Flux.1 schnell, sequenced around the language model by the bus so the two never contend for VRAM. Photoreal people and scenes, product and marketing imagery, and store assets, down to the lab\'s own launcher icons.',
   },
 ];
 
@@ -149,12 +157,14 @@ const stack = [
   'Qwen3 family',
   'GGUF quantization',
   'Qdrant',
+  'Obsidian',
   'faster-whisper',
   'Kokoro TTS',
   'ComfyUI',
   'n8n',
   'Open WebUI',
   'Home Assistant',
+  'ntfy',
   'Docker / WSL2',
   'Python',
 ];
@@ -269,8 +279,11 @@ const stack = [
 
         <h3 class="mt-12 text-card-lead text-text-primary">The layers around them</h3>
         <div class="mt-6 grid gap-3 sm:grid-cols-2">
-          {layers.map((l) => (
-            <div class="card p-6">
+          {layers.map((l, i) => (
+            <div class:list={[
+              'card p-6',
+              i === layers.length - 1 && layers.length % 2 === 1 && 'sm:col-span-2',
+            ]}>
               <span class="mono-label text-accent">{l.n}</span>
               <p class="mt-3 text-card-body text-text-secondary">{l.d}</p>
             </div>


### PR DESCRIPTION
## The correction

The coding-agents line claimed Continue, Cline and Aider. Stewart says he has never used them, and the evidence agrees:

| Tool | Evidence |
|---|---|
| Continue | `~/.continue/config.yaml` dated 4 June, pointing at a serving port retired 5 July, key still `PLACEHOLDER_ANTHROPIC_API_KEY`, no `sessions/`, **extension not installed** |
| Aider | Nothing. No config, no VS Code storage |
| Cline / Roo Code | Nothing. Not among the 28 installed extensions |

Root cause: the lab repo's `TECH_STACK.md` lists an *intended* stack, and I read it as a running one. The agents actually in use are Claude Code (installed), OpenAI Codex (`~/.codex/` with config and auth) and GitHub Copilot, steered by portable SKILL.md skills that work across all three.

## Additions Stewart asked for

- **Retrieval memory** names Obsidian instead of "a plain-Markdown vault".
- **Agent memory**, new card: the CLAUDE.md / AGENTS.md and per-project memory layer that persists decisions between sessions. Genuinely different from RAG and worth separating.
- **Home security**, new card, scoped strictly to code that exists (`security/alert_bridge.py`, `ha_watch.py`): armed-camera person events pull the already-captured frame with no streaming, the local vision model describes it, ntfy pushes it, with per-camera cooldowns, empty-frame suppression and quiet hours. **Frigate and the HA dashboard are not claimed** because every phase checkbox in the Eufy plan doc is unticked.
- **Image generation** no longer reduces itself to launcher icons.

## Withheld on purpose

Camera count, room coverage, vendor, HomeBase IP and the ntfy hostname. A home security topology published next to a real name and city is not a good trade.

## Verification

Build clean, 31 pages. Playwright at 1280: 8 layer cards render in 4 even rows, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3