### PR TITLE
Frenchie Trivia is live on both stores, not in development

### DIFF
--- a/site/src/content/work/frenchie-trivia.md
+++ b/site/src/content/work/frenchie-trivia.md
@@ -1,7 +1,7 @@
 ---
 title: "Frenchie Trivia"
 category: "product"
-status: "In development · iOS/Android"
+status: "Live · iOS + Android"
 order: 8
 role: "Solo builder"
 summary: "A French Bulldog trivia mobile app with 1,100 questions across 14 categories - ranked play, daily challenges, global and country leaderboards, and a fully offline-capable game engine, built with Firebase auth and a Cloudflare Workers backend."
@@ -33,4 +33,4 @@ flowchart LR
 
 ## Status
 
-In active development. Backend live on Cloudflare Workers; the marketing site is live at [frenchietrivia.com](https://frenchietrivia.com) with a playable demo. Android is in Google Play closed testing; iOS TestFlight and App Store submission are next.
+Live on the iOS App Store and Google Play, and still shipping. First released in March 2026, now on version 1.4.1 - which added an offline score queue with idempotent submission so a retried score can never double-count, anti-repeat question selection backed by a persisted LRU of recently served questions, category mastery medals, and a pinned rank row for players outside the visible top 100. Backend on Cloudflare Workers; the marketing site at [frenchietrivia.com](https://frenchietrivia.com) carries a playable demo.


### PR DESCRIPTION
## Verified first

| Source | Result |
|---|---|
| iTunes lookup, id 6760307444 | Frenchie Trivia, v1.4.1, free, seller Stewart Burton, released 2026-03-25, current version 2026-07-31 |
| Google Play, com.frenchietrivia.app | Public listing resolves |
| Repo | v1.4.1, release notes committed, production image pinned |

The repo README still has `[ ] App Store submission` unticked, so it wasn't the thing to trust.

## Change

`status` flips from `In development · iOS/Android` to `Live · iOS + Android`, which moves the card into the live group on `/smaller-things`. Because those counts are derived from the content collection, the group headers (7 / 3 / 2) and the homepage's "7 of them live" updated with no further edits.

The Status section now covers what shipped since launch instead of what was next: offline score queue with idempotent submission so a retried score can't double-count, anti-repeat question selection over a persisted LRU, category mastery medals, and the pinned rank row for players outside the top 100.

Question count (1,100), categories (14) and the five languages re-checked against the repo, unchanged. Resume and one-pager don't mention Frenchie Trivia, so nothing to sync there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3