### PR TITLE
Add the media pipeline layer to the lab

### DIFF
--- a/site/src/pages/lab.astro
+++ b/site/src/pages/lab.astro
@@ -80,6 +80,10 @@ const layers = [
     n: 'Image generation',
     d: 'ComfyUI running SDXL and Flux.1 schnell, sequenced around the language model by the bus so the two never contend for VRAM. Photoreal people and scenes, product and marketing imagery, and store assets, down to the lab\'s own launcher icons.',
   },
+  {
+    n: 'Media pipeline',
+    d: 'App Store previews and social cuts are built by script rather than by hand in an editor: ffmpeg does the splicing, audio mixing and fades, caption burn-in and encoding, hitting Apple\'s App Preview rules exactly (portrait, constant 30fps, a native device size with no scaling, real captured gameplay rather than cinematic footage). Generated clips are stitched around the limits of whatever produced them, one cut joining two generations because the generator caps at fifteen seconds. Imagery is a deliberate mix of local models and cloud ones; audio pairs generated sound with a properly licensed field recording. Scripting it means a re-cut is a re-run, and the reasoning sits in the script instead of in someone\'s memory.',
+  },
 ];
 
 const routing = [
@@ -161,6 +165,7 @@ const stack = [
   'faster-whisper',
   'Kokoro TTS',
   'ComfyUI',
+  'ffmpeg',
   'n8n',
   'Open WebUI',
   'Home Assistant',


### PR DESCRIPTION
## Evidence

Stewart confirmed local video editing and audio work for Hadeda Havoc media. It's in `hadeda/tools/ad/`:

| Signal | Count |
|---|---|
| `ffmpeg` invocations | 42 |
| `concat` | 35 |
| `drawtext` | 19 |
| `afade` | 19 |
| `amix` | 10 |

**Not DaVinci Resolve** - the earlier "resolve" grep hits were `Promise.resolve` in the capture scripts. Resolve is another entry in the lab repo's intended-tools list that was never used.

## What the scripts do

- `build_app_preview.sh` assembles an App Store App Preview from a real capture, with Apple's rules driving every choice: 15-30s, portrait, constant 30fps, a native 6.9" size at 1320x2868 so nothing is scaled, real gameplay rather than cinematic footage. Audio is laid in afterwards because the recorder captures video only.
- `build_six_cities_v3.sh` splices two generations together because the generator caps at 15s, and rebuilds the audio because it invents a bird call regardless of the flag telling it not to.
- Timed segment lists drive caption burn-in with a bundled font.

The card states imagery as a mix of local and cloud models, which is what happened, and audio as generated sound plus a licensed field recording.

## Layout

Nine layer cards makes an odd count, so the column-span rule added earlier runs the last card full width (896px vs 440px) instead of leaving it orphaned. No overflow at 1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3