### PR TITLE
Document the three-way page split and the verify-before-publishing rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The repo also holds the multi-page CV and the single-page recruiter handout - bo
 | | |
 |---|---|
 | Site | [`www.stewart-burton.com`](https://www.stewart-burton.com) |
-| Work index | [`/work`](https://www.stewart-burton.com/work) |
+| Work index | [`/work`](https://www.stewart-burton.com/work) <sub>· enterprise AI/DevOps only</sub> |
+| Independent products | [`/smaller-things`](https://www.stewart-burton.com/smaller-things) <sub>· grouped live / in build / personal</sub> |
+| Home AI lab | [`/lab`](https://www.stewart-burton.com/lab) <sub>· the platform underneath</sub> |
 | Certifications | [`/certifications`](https://www.stewart-burton.com/certifications) <sub>· inline PDF modal viewer</sub> |
 | CV (4-page) | [`/resume/...Resume.pdf`](https://www.stewart-burton.com/resume/Stewart_Burton_AI_DevOps_Engineer_Resume.pdf) |
 | One-pager | [`/resume/...Profile.pdf`](https://www.stewart-burton.com/resume/Stewart_Burton_AI_DevOps_Engineer_Profile.pdf) |
@@ -53,9 +55,9 @@ The repo also holds the multi-page CV and the single-page recruiter handout - bo
 .
 ├── site/                                # Astro source - the live site
 │   ├── src/
-│   │   ├── pages/                       # /, /work, /about, /services, /contact, /certifications
-│   │   ├── pages/work/[...slug].astro   # case-study template
-│   │   ├── content/work/                # 16 case studies (Markdown + frontmatter)
+│   │   ├── pages/                       # /, /work, /smaller-things, /lab, /about, /services, /contact, /certifications
+│   │   ├── pages/work/[...slug].astro   # case-study template (serves both enterprise and product entries)
+│   │   ├── content/work/                # 21 case studies (Markdown + frontmatter): 9 enterprise, 12 product
 │   │   ├── content/config.ts            # collection schema
 │   │   ├── components/                  # TopNav · Footer · SectionLabel · StackChips · MermaidEnhancer · WorkCard · SpeakingCard · SpeakingEmbed
 │   │   ├── layouts/Base.astro
@@ -80,6 +82,26 @@ The repo also holds the multi-page CV and the single-page recruiter handout - bo
 ```
 
 <sub>The legacy static site (`index.html`, `style.css`, `script.js`) at the repo root is from before the rebuild. It's not served - only the Astro `site/dist/` build is.</sub>
+
+---
+
+##### `›` SITE STRUCTURE
+
+Three bodies of work, one page each, no product described in two places:
+
+| Page | Owns | Source |
+|---|---|---|
+| `/work` | Enterprise AI/DevOps case studies | `content/work/` where `category` is `enterprise` or `open-source` |
+| `/smaller-things` | Independent products, grouped live / in build / personal | `content/work/` where `category` is `product`, grouped by the `status` prefix |
+| `/lab` | The home AI platform | Hand-written `pages/lab.astro`, sourced from `D:\AI\ai-platform-lab` |
+
+Case studies for both categories live at `/work/<slug>`; product pages set their breadcrumb root and nav highlight to `/smaller-things`. `/work/ai-platform-lab` redirects to `/lab` via `redirects` in `astro.config.mjs`.
+
+**Counts are derived, never hardcoded.** The group headers on `/smaller-things`, the case-study count on `/work` and the homepage's "N independent products / N of them live" all read from the content collection, so one `status` change updates every surface at once.
+
+**Grouping depends on the `status` prefix.** `Live` puts a product in the live group; `Personal project` puts it in the personal group; anything else (`Beta`, `In development`, `Private pilot`) lands in the in-build group. Keep the prefix conventional when adding an entry.
+
+**Two content rules on `/lab`:** no port numbers, hostnames or internal IPs, and no tool listed as in-use without install evidence. The source repo documents an *intended* stack next to the running one and does not mark them apart - Continue, Cline, Aider and DaVinci Resolve were all published as in-use before checking, and none of them were. The page carries a dated "stack verified against the lab repo" line; bump it when refreshing.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-08-home-ai-lab-page-design.md
+++ b/docs/superpowers/specs/2026-08-08-home-ai-lab-page-design.md
@@ -1,7 +1,13 @@
 # Home AI lab page (/lab) - design
 
 Date: 2026-08-08
-Status: approved, ready to implement
+Status: shipped in PR #31, then superseded in part.
+
+Two things changed after this was written, both covered in
+[2026-08-09-site-restructure-and-lab-accuracy.md](2026-08-09-site-restructure-and-lab-accuracy.md):
+the "built in this workshop" cards now sit alongside a full `/smaller-things` page,
+and four tool claims taken from the lab repo turned out to describe an intended
+stack rather than a running one.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-08-09-site-restructure-and-lab-accuracy.md
+++ b/docs/superpowers/specs/2026-08-09-site-restructure-and-lab-accuracy.md
@@ -1,0 +1,76 @@
+# Site restructure and lab accuracy pass
+
+Date: 2026-08-09
+Status: shipped (PRs #30-#35)
+
+Follows [2026-08-08-home-ai-lab-page-design.md](2026-08-08-home-ai-lab-page-design.md).
+
+## What changed
+
+| PR | Change |
+|---|---|
+| #30 | SKILL.md described as a portable agent skill format, not a Claude-only one |
+| #31 | Home AI lab promoted from a `/work` case study to `/lab` |
+| #32 | Independent products split onto `/smaller-things`; lab linked to business use |
+| #33 | Coding-agent, memory, security and image claims corrected on `/lab` |
+| #34 | Frenchie Trivia flipped from in-development to live |
+| #35 | Media pipeline layer added to `/lab` |
+
+## The structural decision
+
+Three bodies of work, one page each. `/work` is enterprise only, `/smaller-things`
+owns the 12 independent products, `/lab` owns the platform. The homepage's nine-card
+product grid was a duplicate of `/work`'s product section, so moving it without
+splitting would have produced a third copy of the same 12 summaries.
+
+Case studies stay at `/work/<slug>` so no URLs broke. Product pages set their
+breadcrumb root and nav highlight to `/smaller-things`.
+
+Nav label is "smaller things" by Stewart's explicit choice. It was flagged that this
+undersells App Store products with paying users; he chose it anyway. Do not silently
+rename it to "products".
+
+## Counts are derived
+
+Every count on the homepage, `/work` and `/smaller-things` reads from the content
+collection. Proven when Frenchie Trivia's `status` changed: the group headers moved
+from 6/4/2 to 7/3/2 and the homepage moved from "6 of them live" to "7" with no
+second edit. Never reintroduce a hardcoded count.
+
+Grouping keys off the `status` prefix: `Live` to the live group, `Personal project`
+to personal, everything else to in-build.
+
+## The accuracy problem, and the rule that came out of it
+
+Four claims were published from the lab repo's docs and were wrong. Stewart caught
+the first; the rest came out of checking the same way.
+
+| Claim | Reality |
+|---|---|
+| Continue, Cline, Aider as coding agents | No Aider config, no Cline extension. Continue's config dated 4 June against a port retired 5 July, key still `PLACEHOLDER_ANTHROPIC_API_KEY`, no sessions dir, extension not installed |
+| LM Studio serving the flagship models | Retired from the serving path 2026-07-05; llama.cpp + llama-swap serve now |
+| nomic-embed-text for RAG | `qwen3-embedding:0.6b` at 1024 dimensions |
+| DaVinci Resolve for video | Scripted ffmpeg in `hadeda/tools/ad` - 42 invocations, concat, drawtext, afade, amix |
+
+Root cause: `D:\AI\ai-platform-lab` documents an intended stack next to the running
+one without marking them apart, and unticked checklists sit next to working code
+(`docs/eufy-integration.md` has every phase unticked while `security/alert_bridge.py`
+and `ha_watch.py` run).
+
+**Rule: no tool goes on the site as in-use without install evidence.** Check
+`~/.vscode/extensions`, a real config with no placeholder values, a sessions or
+history directory, `~/.codex/`, `~/.claude/`. For a shipped product, check the store,
+not the repo README - Frenchie Trivia's README still has `[ ] App Store submission`
+unticked while the app has been live since March.
+
+## Publishing restraint on `/lab`
+
+Withheld deliberately, and the reasoning should survive: no port numbers, no
+hostnames, no internal IPs, no home-security camera count, room coverage or vendor.
+A working description of a home security topology published beside a real name and
+city is not a good trade. The agent-autonomy section states the permissive config
+that actually runs rather than only the written design posture.
+
+## Follow-up not done
+
+Resume, one-pager and LinkedIn do not yet reference `/lab` or `/smaller-things`.


### PR DESCRIPTION
Documentation catch-up for PRs #30-#35.

## README

Was describing a site with `/work`, `/about`, `/services`, `/contact` and 16 case studies. Now carries `/smaller-things` and `/lab`, the real counts (21 entries: 9 enterprise, 12 product), and a new **SITE STRUCTURE** section:

- the three-bodies-of-work split and which source feeds each page
- case studies stay at `/work/<slug>`; product pages point their breadcrumb and nav at `/smaller-things`
- `/work/ai-platform-lab` redirects to `/lab`
- **counts are derived, never hardcoded** - one `status` change updates every surface
- grouping keys off the `status` prefix, so keep it conventional when adding entries
- the two `/lab` content rules: no ports/hostnames/IPs, and no tool listed as in-use without install evidence

## New decision record

`docs/superpowers/specs/2026-08-09-site-restructure-and-lab-accuracy.md` records the restructure and the accuracy pass, including the four wrong claims and their root cause (the lab repo documents an intended stack next to the running one without marking them apart, and unticked checklists sit beside working code).

The 2026-08-08 lab spec is marked shipped and points forward to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1jer5yZ6QyCQf9haXZHH3